### PR TITLE
fix: unbreak MeshProvider build + demo proxy URL (v0.3.0)

### DIFF
--- a/examples/with-vite-react/src/components/HydraCommit.tsx
+++ b/examples/with-vite-react/src/components/HydraCommit.tsx
@@ -28,7 +28,24 @@ interface LogEntry {
   payload?: unknown;
 }
 
-const HYDRA_URL = import.meta.env.VITE_HYDRA_NODE_URL as string | undefined;
+const RAW_HYDRA_URL = import.meta.env.VITE_HYDRA_NODE_URL as string | undefined;
+
+/**
+ * Resolve the configured hydra-node URL. A relative value (e.g. "/hydra") is
+ * resolved against the current page origin — using wss:// on HTTPS pages and
+ * ws:// on HTTP — so the app works behind any reverse proxy / tunnel without a
+ * rebuild. Absolute ws(s):// URLs are used verbatim.
+ */
+function resolveNodeUrl(raw: string | undefined): string {
+  if (!raw) return "";
+  if (raw.startsWith("/")) {
+    const proto = window.location.protocol === "https:" ? "wss" : "ws";
+    return `${proto}://${window.location.host}${raw}`;
+  }
+  return raw;
+}
+
+const HYDRA_URL = resolveNodeUrl(RAW_HYDRA_URL);
 
 function wsToHttp(wsUrl: string): string {
   return wsUrl.replace(/^ws(s?):\/\//, "http$1://");

--- a/packages/hydra-sdk/src/Provider/MeshProvider.ts
+++ b/packages/hydra-sdk/src/Provider/MeshProvider.ts
@@ -15,7 +15,6 @@ import type {
   GovernanceProposalInfo,
   IEvaluator,
   IFetcher,
-  IFetcherOptions,
   IListener,
   ISubmitter,
   Protocol,
@@ -190,7 +189,7 @@ export class HydraMeshProvider
   /** Not supported on Hydra L2. */
   fetchAddressTxs(
     _address: string,
-    _options?: IFetcherOptions,
+    _options?: unknown,
   ): Promise<TransactionInfo[]> {
     return notSupported("fetchAddressTxs");
   }

--- a/packages/hydra-sdk/src/Provider/MeshProvider.ts
+++ b/packages/hydra-sdk/src/Provider/MeshProvider.ts
@@ -37,7 +37,7 @@ import { fromHydraMeshUtxoMap } from "./mesh-utxo.js";
 // ---------------------------------------------------------------------------
 
 /** Fetches the full UTxO snapshot from hydra-node and converts to MeshJS shape. */
-const getAllMeshUtxos = (httpUrl: string): Promise<MeshUTxO[]> =>
+const getAllMeshUtxos = (httpUrl: string): Promise<Array<MeshUTxO>> =>
   Effect.runPromise(
     getSnapshotUtxo(httpUrl).pipe(
       Effect.map((utxoMap) =>
@@ -119,7 +119,7 @@ export class HydraMeshProvider
    * Fetches UTxOs at the given address from the L2 snapshot.
    * Optionally filters by asset unit.
    */
-  async fetchAddressUTxOs(address: string, asset?: string): Promise<MeshUTxO[]> {
+  async fetchAddressUTxOs(address: string, asset?: string): Promise<Array<MeshUTxO>> {
     const all = await getAllMeshUtxos(this.httpUrl);
     let filtered = all.filter((u) => u.output.address === address);
     if (asset) {
@@ -133,7 +133,7 @@ export class HydraMeshProvider
   /**
    * Fetches UTxOs by transaction hash (and optional output index) from the L2 snapshot.
    */
-  async fetchUTxOs(hash: string, index?: number): Promise<MeshUTxO[]> {
+  async fetchUTxOs(hash: string, index?: number): Promise<Array<MeshUTxO>> {
     const all = await getAllMeshUtxos(this.httpUrl);
     return all.filter(
       (u) =>
@@ -190,14 +190,14 @@ export class HydraMeshProvider
   fetchAddressTxs(
     _address: string,
     _options?: unknown,
-  ): Promise<TransactionInfo[]> {
+  ): Promise<Array<TransactionInfo>> {
     return notSupported("fetchAddressTxs");
   }
 
   /** Not supported on Hydra L2. */
   fetchAssetAddresses(
     _asset: string,
-  ): Promise<{ address: string; quantity: string }[]> {
+  ): Promise<Array<{ address: string; quantity: string }>> {
     return notSupported("fetchAssetAddresses");
   }
 
@@ -215,7 +215,7 @@ export class HydraMeshProvider
   fetchCollectionAssets(
     _policyId: string,
     _cursor?: number | string,
-  ): Promise<{ assets: Asset[]; next?: string | number | null }> {
+  ): Promise<{ assets: Array<Asset>; next?: string | number | null }> {
     return notSupported("fetchCollectionAssets");
   }
 
@@ -273,9 +273,9 @@ export class HydraMeshProvider
    */
   evaluateTx(
     _tx: string,
-    _additionalUtxos?: MeshUTxO[],
-    _additionalTxs?: string[],
-  ): Promise<Omit<Action, "data">[]> {
+    _additionalUtxos?: Array<MeshUTxO>,
+    _additionalTxs?: Array<string>,
+  ): Promise<Array<Omit<Action, "data">>> {
     return notSupported("evaluateTx");
   }
 

--- a/packages/hydra-sdk/src/Provider/index.ts
+++ b/packages/hydra-sdk/src/Provider/index.ts
@@ -6,6 +6,12 @@ export {
 } from "./http.js";
 export { HydraProvider, type HydraProviderConfig } from "./HydraProvider.js";
 export {
+  fromHydraMeshUtxo,
+  fromHydraMeshUtxoMap,
+  toHydraMeshUtxo,
+  toHydraMeshUtxoMap,
+} from "./mesh-utxo.js";
+export {
   HydraMeshProvider,
   type HydraMeshProviderConfig,
 } from "./MeshProvider.js";
@@ -15,9 +21,3 @@ export {
   toHydraUtxo,
   toHydraUtxoMap,
 } from "./utxo.js";
-export {
-  fromHydraMeshUtxo,
-  fromHydraMeshUtxoMap,
-  toHydraMeshUtxo,
-  toHydraMeshUtxoMap,
-} from "./mesh-utxo.js";

--- a/packages/hydra-sdk/src/Provider/mesh-utxo.ts
+++ b/packages/hydra-sdk/src/Provider/mesh-utxo.ts
@@ -40,7 +40,7 @@ export const fromHydraMeshUtxo = (key: string, txOut: TxOut): MeshUTxO => {
  */
 export const fromHydraMeshUtxoMap = (
   utxoMap: Record<string, TxOut>,
-): MeshUTxO[] =>
+): Array<MeshUTxO> =>
   Object.entries(utxoMap).map(([key, txOut]) => fromHydraMeshUtxo(key, txOut));
 
 // ---------------------------------------------------------------------------
@@ -104,8 +104,8 @@ export const toHydraMeshUtxoMap = (
 // ---------------------------------------------------------------------------
 
 /** Convert hydra-node Value to MeshJS Asset array. */
-const hydraValueToMeshAssets = (value: Value): Asset[] => {
-  const assets: Asset[] = [];
+const hydraValueToMeshAssets = (value: Value): Array<Asset> => {
+  const assets: Array<Asset> = [];
 
   if (value.lovelace !== undefined) {
     assets.push({ unit: "lovelace", quantity: String(value.lovelace) });

--- a/packages/hydra-sdk/test/Provider/MeshProvider.test.ts
+++ b/packages/hydra-sdk/test/Provider/MeshProvider.test.ts
@@ -7,6 +7,8 @@ import type {
 import { Head, Provider } from "@no-witness-labs/hydra-sdk";
 import { describe, expect, it } from "vitest";
 
+import type { TxOut } from "../../src/Protocol/Types.js";
+
 const { HydraMeshProvider } = Provider;
 
 // ---------------------------------------------------------------------------
@@ -280,7 +282,7 @@ describe("Provider / mesh-utxo conversion", () => {
       value: {
         lovelace: 2_000_000,
         [policyId]: { [assetName]: 100 },
-      } as import("../../src/Protocol/Types.js").TxOut["value"],
+      } as TxOut["value"],
     });
 
     expect(utxo.output.amount).toContainEqual({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@evolution-sdk/evolution':
         specifier: '>=0.3.22'
         version: 0.3.25(@effect/cluster@0.56.3(@effect/platform@0.90.10(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.90.10(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.90.10(effect@3.19.16))(effect@3.19.16))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@meshsdk/common':
+        specifier: '>=1.8.0'
+        version: 1.8.14
       '@noble/hashes':
         specifier: ^1.7.0
         version: 1.8.0
@@ -1516,6 +1519,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@meshsdk/common@1.8.14':
+    resolution: {integrity: sha512-rKkgaxX5c0XOZ0Wxwp1WkQ8B79QuwGAy9t7KSofDz3NoIsW4SVY2nKWJ0N0tQdwv+hSw4xvM5AXIsyzkLHO3Ow==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -3157,6 +3163,12 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  blake2b-wasm@2.4.0:
+    resolution: {integrity: sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==}
+
+  blake2b@2.1.4:
+    resolution: {integrity: sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==}
 
   block-iterator@1.1.2:
     resolution: {integrity: sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w==}
@@ -5227,6 +5239,9 @@ packages:
 
   nan@2.25.0:
     resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
+
+  nanoassert@2.0.0:
+    resolution: {integrity: sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8049,6 +8064,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@meshsdk/common@1.8.14':
+    dependencies:
+      bech32: 2.0.0
+      bip39: 3.1.0
+      blake2b: 2.1.4
+    transitivePeerDependencies:
+      - react-native-b4a
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -9897,6 +9920,20 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  blake2b-wasm@2.4.0:
+    dependencies:
+      b4a: 1.8.0
+      nanoassert: 2.0.0
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  blake2b@2.1.4:
+    dependencies:
+      blake2b-wasm: 2.4.0
+      nanoassert: 2.0.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   block-iterator@1.1.2: {}
 
@@ -12452,6 +12489,8 @@ snapshots:
 
   nan@2.25.0:
     optional: true
+
+  nanoassert@2.0.0: {}
 
   nanoid@3.3.11: {}
 


### PR DESCRIPTION
## Summary
Prepares the **Provider Layer & Testnet Hardening (Milestone 3 / v0.3.0)** deliverables by fixing the currently-broken MeshJS provider build and making the hosted demo work behind a reverse proxy/tunnel.

## Changes
- **fix(hydra-sdk): MeshProvider build with `@meshsdk/common >=1.8`**
  - `MeshProvider.ts` imported `IFetcherOptions`, which is **not exported** by `@meshsdk/common` (resolved 1.8.14) → `tsc` failed, so `@no-witness-labs/hydra-sdk` did not build.
  - Drop the bad import; type the unused `fetchAddressTxs` param as `unknown` (behavior unchanged — it only throws "not supported").
  - **Lockfile:** committed `pnpm-lock.yaml` was missing `@meshsdk/common`, so `pnpm install --frozen-lockfile` (CI default) failed with `ERR_PNPM_OUTDATED_LOCKFILE`. Now locked.
- **feat(example): resolve hydra node URL from page origin**
  - Relative `VITE_HYDRA_NODE_URL` (e.g. `/hydra`) resolves to `wss://`/`ws://` on the current origin, so the demo works behind any reverse proxy / Cloudflare tunnel without per-URL rebuilds.

## Why
- `main` currently fails both `tsc -b` (MeshProvider) and `--frozen-lockfile` installs. This unbreaks the build that the v0.3.0 provider milestone depends on.
- The example change supports the **hosted demo app URL** evidence item (served via Traefik :80 + HTTPS tunnel).

## Test
- `pnpm --filter @no-witness-labs/hydra-sdk type-check` ✅ and full `build` ✅
- `pnpm install --frozen-lockfile` ✅
- Demo built with `VITE_HYDRA_NODE_URL=/hydra`, deployed, wallet connect + L2 provider verified over HTTPS.

The pending `.changeset/mesh-provider-adapter.md` (hydra-sdk minor) covers the SDK version bump; the example app is private (no changeset). The `v0.3.0` milestone tag is created on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)