### PR TITLE
release: v1.0.0 prep — major changeset, Release Notes docs, demo docs link

### DIFF
--- a/.changeset/v1-stable-release.md
+++ b/.changeset/v1-stable-release.md
@@ -1,0 +1,16 @@
+---
+"@no-witness-labs/hydra-sdk": major
+"@no-witness-labs/hydra-sdk-cli": major
+---
+
+v1.0.0 — first stable release.
+
+The public API is now considered stable and versioned under semantic versioning:
+
+- Hydra Head lifecycle management (init, commit, incremental commit/decommit, close, contest, fanout, abort) targeting hydra-node v1.2.0
+- `HydraStateMachine` with typed head-state transitions and event subscriptions
+- Provider layer: `HydraProvider` (evolution-sdk) and `HydraMeshProvider` (MeshJS) adapters behind one interface
+- Automatic WebSocket connection recovery
+- CLI with standalone binaries for linux-x64/arm64, darwin-x64/arm64, and windows-x64
+
+From this release on, breaking changes to any documented API will only ship in a new major version, per semver.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -10,6 +10,7 @@
     "cli",
     "error-handling",
     "modules",
+    "release-notes",
     "compatibility",
     "faq"
   ]

--- a/docs/content/docs/modules/index.mdx
+++ b/docs/content/docs/modules/index.mdx
@@ -7,6 +7,8 @@ description: API documentation for all Hydra SDK packages
 
 This section contains API documentation for all packages in the Hydra SDK monorepo.
 
+This reference documents **v1.0.0** of the SDK. The API is versioned under [semantic versioning](https://semver.org); to see what changed between versions, check the [Release Notes](/docs/release-notes) or install a specific version with `npm i @no-witness-labs/hydra-sdk@<version>`.
+
 ## Packages
 
 - [@no-witness-labs/hydra-sdk](/docs/modules/hydra-sdk) — Core SDK for Hydra Head protocol management

--- a/docs/content/docs/release-notes.mdx
+++ b/docs/content/docs/release-notes.mdx
@@ -1,0 +1,47 @@
+---
+title: Release Notes
+description: Version history, release highlights, and versioning policy for the Hydra SDK.
+---
+
+# Release Notes
+
+All packages are published to npm under the `@no-witness-labs` scope and follow [semantic versioning](https://semver.org). Every release is driven by [changesets](https://github.com/changesets/changesets), published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) (signed, verifiable build attestations), and tagged on GitHub.
+
+- npm: [@no-witness-labs/hydra-sdk](https://www.npmjs.com/package/@no-witness-labs/hydra-sdk) · [@no-witness-labs/hydra-sdk-cli](https://www.npmjs.com/package/@no-witness-labs/hydra-sdk-cli) · [@no-witness-labs/hydra-devnet](https://www.npmjs.com/package/@no-witness-labs/hydra-devnet)
+- GitHub releases: [no-witness-labs/hydra-sdk/releases](https://github.com/no-witness-labs/hydra-sdk/releases)
+- Full per-package changelogs: [hydra-sdk](https://github.com/no-witness-labs/hydra-sdk/blob/main/packages/hydra-sdk/CHANGELOG.md) · [hydra-sdk-cli](https://github.com/no-witness-labs/hydra-sdk/blob/main/packages/hydra-sdk-cli/CHANGELOG.md)
+
+## v1.0.0 — Stable release
+
+First stable release. The documented public API is now stable: breaking changes will only ship in a new major version.
+
+- Complete Hydra Head lifecycle: init, commit, incremental commit/decommit, close, contest, fanout, abort (hydra-node v1.2.0)
+- `HydraStateMachine` with typed head-state transitions and event subscriptions
+- Provider layer with two adapters behind one interface: `HydraProvider` (evolution-sdk) and `HydraMeshProvider` (MeshJS)
+- Automatic WebSocket connection recovery
+- CLI with standalone binaries (linux-x64/arm64, darwin-x64/arm64, windows-x64)
+
+> **Note on the package name:** the original Project Catalyst proposal referred to this package as `hydra-manager`. That name was already taken on the npm registry by an unrelated package, so the SDK is published as [`@no-witness-labs/hydra-sdk`](https://www.npmjs.com/package/@no-witness-labs/hydra-sdk) instead.
+
+## v0.3.0 — Provider Layer & Testnet Hardening
+
+[GitHub release](https://github.com/no-witness-labs/hydra-sdk/releases/tag/v0.3.0)
+
+- `HydraMeshProvider`: MeshJS provider adapter implementing `IFetcher`, `ISubmitter`, `IEvaluator`, and `IListener`, with a tree-shakeable `./mesh-provider` subpath export
+- Bidirectional UTxO converters between hydra-node and MeshJS formats
+- Cross-browser (Chromium/Firefox/WebKit) and cross-platform (Linux/macOS/Windows) test matrix in CI
+- Node-resilience tests (hydra-node drop/restart with automatic reconnect)
+- Provider documentation: [Providers](/docs/providers), [Testing](/docs/providers/testing), [Limits](/docs/providers/limits), [Production Checklist](/docs/providers/production-checklist)
+
+## v0.2.0 — Hydra Transactions & UTXO Query
+
+[GitHub release](https://github.com/no-witness-labs/hydra-sdk/releases/tag/v0.2.0)
+
+- L2 transaction submission and UTxO querying inside an open head
+- `HydraStateMachine` for typed head-state tracking
+- CLI standalone binary compilation (Bun) with release automation
+- npm publishing with provenance
+
+## Earlier releases
+
+Initial development releases (0.0.x) established the WebSocket wrapper around the hydra-node API, package structure, and CI. See the [per-package changelogs](https://github.com/no-witness-labs/hydra-sdk/blob/main/packages/hydra-sdk/CHANGELOG.md) for details.

--- a/examples/with-vite-react/src/App.tsx
+++ b/examples/with-vite-react/src/App.tsx
@@ -7,14 +7,34 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100">
-      <header className="border-b border-gray-800 px-6 py-4">
-        <h1 className="text-xl font-semibold">
-          Hydra SDK — Wallet Connect Example
-        </h1>
-        <p className="mt-1 text-sm text-gray-400">
-          Connect a CIP-30 wallet and interact with a Hydra Head on Preview
-          testnet.
-        </p>
+      <header className="flex items-start justify-between border-b border-gray-800 px-6 py-4">
+        <div>
+          <h1 className="text-xl font-semibold">
+            Hydra SDK — Wallet Connect Example
+          </h1>
+          <p className="mt-1 text-sm text-gray-400">
+            Connect a CIP-30 wallet and interact with a Hydra Head on Preview
+            testnet.
+          </p>
+        </div>
+        <nav className="flex gap-4 text-sm">
+          <a
+            href="https://no-witness-labs.github.io/hydra-sdk/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-indigo-400 hover:text-indigo-300"
+          >
+            Docs
+          </a>
+          <a
+            href="https://github.com/no-witness-labs/hydra-sdk"
+            target="_blank"
+            rel="noreferrer"
+            className="text-indigo-400 hover:text-indigo-300"
+          >
+            GitHub
+          </a>
+        </nav>
       </header>
 
       <main className="mx-auto max-w-4xl space-y-6 p-6">


### PR DESCRIPTION
Prepares the final Catalyst milestone v1.0.0 release.

- Major changeset: `@no-witness-labs/hydra-sdk` and `@no-witness-labs/hydra-sdk-cli` → 1.0.0 (stable API declaration)
- Docs: new **Release Notes** page (version history, semver/provenance policy, `hydra-manager` rename note) added to nav
- Docs: API Reference index now states the documented version (versioned API criterion)
- Demo app (`with-vite-react`): header links to docs site and GitHub (demo-links-to-docs criterion)

After merge, the changesets bot will update the version-packages PR (#83) to 1.0.0; merging that publishes to npm with provenance and creates the package GitHub releases + CLI binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)