### PR TITLE
ci: bump publish workflows to Node 22

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org/"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org/'
 


### PR DESCRIPTION
npm@12 (installed via `npm install -g npm@latest` for trusted publishing) now requires Node >=22; the Release run on main failed with EBADENGINE on Node 20. Bumps the two publishing workflows (release.yml, rc.yml) to Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)