### PR TITLE
ci: pin npm@11 in publish workflows

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -39,7 +39,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Update npm to latest (required for trusted publishing)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Update npm to latest (required for trusted publishing)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
npm@12 hard-rejects the `--git-checks` flag that `changeset publish` passes through pnpm, which broke publishing of `hydra-sdk@1.0.0` and `hydra-devnet` (EUNKNOWNCONFIG). npm@11 — used by all previously successful releases — supports both trusted publishing and this flag. Pin it instead of `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)