### PR TITLE
docs: credit both X accounts in close-out report

### DIFF
--- a/CLOSEOUT_REPORT.md
+++ b/CLOSEOUT_REPORT.md
@@ -48,7 +48,7 @@ The Cardano Open: Developers challenge funds open-source developer tooling that 
 - **npm downloads (Dec 2025 – Jul 2026):** 316 (`hydra-sdk`) + 399 (`hydra-sdk-cli`) = 715+ installs during the funded period, before the v1.0.0 stability declaration.
 - **Contributors:** 5 people contributed to the repository.
 - **Demo interactions:** the hosted demo has been used to open, commit to, transact in, and fan out real Hydra heads on Cardano preprod (transaction evidence visible on preprod explorers via the demo's head address).
-- **Social reach:** development updates posted on X throughout the project — see the [social plan spreadsheet](_TBD — Google Sheet link_); **total interactions: _TBD from X Analytics_** (impressions, likes, reposts, replies across all project posts).
+- **Social reach:** development updates posted on X throughout the project via [@nowitnesslabs](https://x.com/nowitnesslabs) and [@solidsnakedev](https://x.com/solidsnakedev) — see the [social plan spreadsheet](_TBD — Google Sheet link_); **total interactions: _TBD from X Analytics_** (impressions, likes, reposts, replies across all project posts).
 
 ## Impact
 
@@ -102,6 +102,6 @@ Hydra is production-ready protocol machinery; what it lacked was an approachable
 - **Docs:** https://no-witness-labs.github.io/hydra-sdk/
 - **Demo:** http://178.63.100.104/
 - **npm:** https://www.npmjs.com/package/@no-witness-labs/hydra-sdk
-- **X:** https://x.com/nowitnesslabs
+- **X:** https://x.com/nowitnesslabs · https://x.com/solidsnakedev
 - **Social plan spreadsheet:** _[TBD — Google Sheet link]_
 - **Close-out video:** _[TBD — YouTube link]_


### PR DESCRIPTION
Adds @solidsnakedev alongside @nowitnesslabs as project-update channels in the PCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)